### PR TITLE
fix typos in 11-Marginal_MCMC.tex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 *.dvi
 *.xdv
 *-converted-to.*
+*.dep
+*.table
 # these rules might exclude image files for figures etc.
 # *.ps
 # *.eps

--- a/slides/11-Marginal_MCMC.tex
+++ b/slides/11-Marginal_MCMC.tex
@@ -32,10 +32,10 @@
 \begin{frame}{Sample-Then-Marginalize vs Marginalize-Then-Sample}
 	\begin{vfilleditems}
 		\item There are 2 ways to marginalize out the subject-specific parameters:
-			\begin{vfilleditems}
-				\item Sample from the joint posterior and then ignore the subject-specific parameters. You can easily do this using \lstinline{BayesMCMC}.
-				\item Integrate the subject-specific parameters out and then sample from the conditional posterior only. This is what \lstinline{MarginalMCMC} does in \lstinline{Pumas}.
-			\end{vfilleditems}
+		\begin{vfilleditems}
+			\item Sample from the joint posterior and then ignore the subject-specific parameters. You can easily do this using \lstinline{BayesMCMC}.
+			\item Integrate the subject-specific parameters out and then sample from the marginal posterior only. This is what \lstinline{MarginalMCMC} does in \lstinline{Pumas}.
+		\end{vfilleditems}
 		\item The marginal posterior probability is proportional to:
 		$$
 			P(\theta \mid \text{data}) \propto P(\theta, \text{data}) = \int_{\eta_3} \int_{\eta_2} \int_{\eta_1} P(\theta, \eta_1, \eta_2, \eta_3, \text{data}) d\eta_1 d\eta_2 d\eta_3
@@ -46,7 +46,7 @@
 
 \subsection{Hierarchical Models}
 \begin{frame}{Hierarchical Models}
-    For hierarchical models, we can further break down the joint probability into the product of independent conditionals and $P(\theta)$:
+	For hierarchical models, we can further break down the joint probability into the product of independent conditionals and $P(\theta)$:
 	$$
 		P(\theta, \eta_1, \eta_2, \eta_3, \text{data}) = P(\theta) \cdot \prod_{i=1}^3 P(\eta_i, \text{data}_i \mid \theta)
 	$$
@@ -58,7 +58,7 @@
 	$$
 		\begin{aligned}
 			P(\theta, \text{data}) & = \int_{\eta_3} \int_{\eta_2} \int_{\eta_1} P(\theta) \cdot \prod_{i=1}^3 P(\eta_i, \text{data}_i \mid \theta) d\eta_1 d\eta_2 d\eta_3 \\
-			& = P(\theta) \cdot \prod_{i=1}^3 \int_{\eta_i} P(\eta_i, \text{data}_i \mid \theta) d\eta_i
+			                       & = P(\theta) \cdot \prod_{i=1}^3 \int_{\eta_i} P(\eta_i, \text{data}_i \mid \theta) d\eta_i
 		\end{aligned}
 	$$
 	\vfill
@@ -68,7 +68,7 @@
 \begin{frame}{Approximate Marginalization}
 	\begin{vfilleditems}
 		\item The \lstinline{MarginalMCMC} algorithm in Pumas uses approximate integration methods, e.g. the Laplace method or the first order conditional estimation (FOCE) approximation of the Laplace method to compute the subject-specific integrals.
-		\item This approximation is accurate if the conditional posterior $P(\eta_i | \theta, \text{data}_i$ is approximately Gaussian.
+		\item This approximation is accurate if the conditional posterior $P(\eta_i | \theta, \text{data}_i)$ is approximately Gaussian.
 		\item This is often the case if the model is conditionally identifiable wrt $\eta_i$ after fixing $\theta$ and there is enough data per subject to identify the true parameters $\eta_i$.
 	\end{vfilleditems}
 \end{frame}
@@ -96,13 +96,13 @@
 	\small
 	\begin{tabular}{|l|p{.3\textwidth}|p{.3\textwidth}|}
 		\toprule
-        & \textcolor{blue}{\textbf{Marginal MCMC}} & \textcolor{red}{\textbf{Joint MCMC}} \\ \midrule
-		\textbf{Number of parameters} & Low & High \\ \midrule
-		\textbf{Accuracy} & Approximate even for infinite samples unless the conditional posterior $P(\eta_i \mid \theta, \text{data}_i)$ is Gaussian & Exact with infinite samples \\ \midrule
-		\textbf{Cost per HMC step} & High & Low \\ \midrule
-		\textbf{Mass matrix} & Dense & Diagonal (by default) \\ \midrule
-		\textbf{Max tree depth} & Often low & Often high \\ \midrule
-		\textbf{Parallelism} & Efficient for all models & Efficient only for difficult models \\
+		                              & \textcolor{blue}{\textbf{Marginal MCMC}}                                                                                  & \textcolor{red}{\textbf{Joint MCMC}} \\ \midrule
+		\textbf{Number of parameters} & Low                                                                                                                       & High                                 \\ \midrule
+		\textbf{Accuracy}             & Approximate even for infinite samples unless the conditional posterior $P(\eta_i \mid \theta, \text{data}_i)$ is Gaussian & Exact with infinite samples          \\ \midrule
+		\textbf{Cost per HMC step}    & High                                                                                                                      & Low                                  \\ \midrule
+		\textbf{Mass matrix}          & Dense                                                                                                                     & Diagonal (by default)                \\ \midrule
+		\textbf{Max tree depth}       & Often low                                                                                                                 & Often high                           \\ \midrule
+		\textbf{Parallelism}          & Efficient for all models                                                                                                  & Efficient only for difficult models  \\
 		\bottomrule
 	\end{tabular}
 \end{frame}
@@ -111,13 +111,13 @@
 	\begin{vfilleditems}
 		\item \textbf{Question}: Can we use prior information to reduce the number of subjects needed in a rare diseases study?
 		\item \textbf{Experiment}:
-			\begin{vfilleditems}
-				\item Given a drug model for a rare disease with long-term disease progression effects and short-term symptomatic effects.
-				\item Simulate 2 population arms in a study – placebo and treatment (trt = 0/1).
-				\item Simulate clinical outcomes for each arm under the assumption that the drug has both long- and short-term effects.
-				\item Run frequentist and Bayesian analysis to infer the drug effects given the synthetic data.
-				\item Identify confidence and credible intervals for parameters.
-			\end{vfilleditems}
+		\begin{vfilleditems}
+			\item Given a drug model for a rare disease with long-term disease progression effects and short-term symptomatic effects.
+			\item Simulate 2 population arms in a study – placebo and treatment (trt = 0/1).
+			\item Simulate clinical outcomes for each arm under the assumption that the drug has both long- and short-term effects.
+			\item Run frequentist and Bayesian analysis to infer the drug effects given the synthetic data.
+			\item Identify confidence and credible intervals for parameters.
+		\end{vfilleditems}
 	\end{vfilleditems}
 \end{frame}
 


### PR DESCRIPTION
Some typos I've found while reviewing for the poster.

There's some formatting by `latexindent` also.