### PR TITLE
fix: simplify to Pumas 2.3.1 syntax

### DIFF
--- a/code/01-pk2cpt.jl
+++ b/code/01-pk2cpt.jl
@@ -48,7 +48,7 @@ pk2cpt_fit = fit(
     pk2cpt,
     pop,
     iparams,
-    Pumas.BayesMCMC(
+    BayesMCMC(
         nsamples=2_000,
         nadapts=1_000,
     ),

--- a/code/02-logistic_regression.jl
+++ b/code/02-logistic_regression.jl
@@ -48,5 +48,5 @@ nausea_fit = fit(
     logistic_model,
     pop,
     init_params(logistic_model),
-    Pumas.BayesMCMC()
+    BayesMCMC()
 )

--- a/code/03-poppk2cpt.jl
+++ b/code/03-poppk2cpt.jl
@@ -66,7 +66,7 @@ poppk2cpt_fit = fit(
     poppk2cpt,
     pop,
     iparams,
-    Pumas.BayesMCMC(
+    BayesMCMC(
         nsamples=100,
         nadapts=10,
     )

--- a/code/04-pkpd.jl
+++ b/code/04-pkpd.jl
@@ -98,7 +98,7 @@ iv_2cmt_ir_fit = fit(
     iv_2cmt_ir,
     pop,
     iparams,
-    Pumas.BayesMCMC(
+    BayesMCMC(
         nsamples=100,
         nadapts=50,
         target_accept=0.5,

--- a/code/05-postprocessing.jl
+++ b/code/05-postprocessing.jl
@@ -73,7 +73,7 @@ poppk2cpt_fit = fit(
     poppk2cpt,
     pop,
     iparams,
-    Pumas.BayesMCMC(
+    BayesMCMC(
         nsamples=1000,
         nadapts=500,
         target_accept = 0.6,

--- a/code/07-diagnostics.jl
+++ b/code/07-diagnostics.jl
@@ -73,7 +73,7 @@ poppk2cpt_fit = fit(
     poppk2cpt,
     pop,
     iparams,
-    Pumas.BayesMCMC(
+    BayesMCMC(
         nsamples=1000,
         nadapts=500,
         target_accept = 0.6,

--- a/code/08-crossvalidation.jl
+++ b/code/08-crossvalidation.jl
@@ -48,7 +48,7 @@ iparams = (; tvcl = 1, tvvc = 70, σ = 0.6, C = float.(Matrix(I(2))), ω = [0.1,
 
 # 4 chains as default
 # Parallel as default across multiple subjects and chains
-pk2cpt_fit = fit(pk2cpt, pop, iparams, Pumas.BayesMCMC(nsamples = 600, nadapts = 300))
+pk2cpt_fit = fit(pk2cpt, pop, iparams, BayesMCMC(nsamples = 600, nadapts = 300))
 
 # Remove the warmup/adapt/burn-in samples
 tr_pk2cpt_fit = Pumas.truncate(pk2cpt_fit; burnin = 300)

--- a/code/09-cp_vs_ncp.jl
+++ b/code/09-cp_vs_ncp.jl
@@ -111,7 +111,7 @@ poppk2cpt_cp_fit = fit(
     poppk2cpt_cp,
     pop[1:2],
     iparams,
-    Pumas.BayesMCMC(
+    BayesMCMC(
         nsamples=200,
         nadapts=100,
         target_accept=0.6,
@@ -122,7 +122,7 @@ poppk2cpt_ncp_fit = fit(
     poppk2cpt_ncp,
     pop[1:2],
     iparams,
-    Pumas.BayesMCMC(
+    BayesMCMC(
         nsamples=200,
         nadapts=100,
         target_accept=0.6,


### PR DESCRIPTION
This PR removes the `Pumas.*()` from calls like `Pumas.BayesMCMC()` and `Pumas.MarginalMCMC()`